### PR TITLE
Change "KATSU!" activity layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,9 @@
             </intent-filter>
         </activity>
         <activity android:name=".presentation.activity.TimelineActivity" />
-        <activity android:name=".presentation.activity.KatsuActivity" />
+        <activity
+            android:name=".presentation.activity.KatsuActivity"
+            android:windowSoftInputMode="adjustResize" />
         <activity
             android:name=".presentation.activity.AccountActivity"
             android:label=""/>

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -68,7 +68,7 @@ class KatsuFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         button_katsu.setOnClickListener {
-            val header = katsu_content_header.text.toString()
+            val header = content_warning_edittext.text.toString()
             val body = katsu_content_body.text.toString()
             val replyTo: Int? =
                     if (arguments.containsKey(PARAM_REPLY_STATUS_ID)) {
@@ -101,7 +101,7 @@ class KatsuFragment : Fragment() {
         }
 
         switch_content_warning.setOnCheckedChangeListener { button, checked ->
-            layout_content_header.visibility = if (checked) View.VISIBLE else View.GONE
+            content_warning_textinput.visibility = if (checked) View.VISIBLE else View.GONE
         }
 
         attach_image_1.setOnClickListener {
@@ -161,9 +161,9 @@ class KatsuFragment : Fragment() {
     }
 
     private fun setHint() {
-        val hintHeader = layout_content_header.hint
-        layout_content_header.hint = null
-        layout_content_header.editText?.hint = hintHeader
+        val hintHeader = content_warning_textinput.hint
+        content_warning_textinput.hint = null
+        content_warning_textinput.editText?.hint = hintHeader
 
         val hintContent = layout_content_body.hint
         layout_content_body.hint = null

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.bl_lia.kirakiratter.presentation.activity.MainActivity">
+    tools:context="com.bl_lia.kirakiratter.presentation.activity.MainActivity"
+    android:fitsSystemWindows="true">
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -10,81 +10,100 @@
 
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:padding="10dp"
         android:background="@color/timeline_bg">
-        
-        <android.support.design.widget.TextInputLayout
+
+        <RelativeLayout
             android:id="@+id/layout_content_header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:layout_alignParentTop="true">
 
-            <EditText
-                android:id="@+id/katsu_content_header"
+            <android.support.design.widget.TextInputLayout
+                android:id="@+id/content_warning_textinput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/hint_content_warning"/>
+                android:visibility="gone"
+                tools:visibility="visible">
 
-        </android.support.design.widget.TextInputLayout>
+                <EditText
+                    android:id="@+id/content_warning_edittext"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hint_content_warning"/>
+
+            </android.support.design.widget.TextInputLayout>
+
+        </RelativeLayout>
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/layout_content_body"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/layout_content_header">
+            android:layout_below="@+id/layout_content_header"
+            android:layout_above="@+id/layout_content_footer">
 
             <EditText
                 android:id="@+id/katsu_content_body"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:gravity="top|start"
-                android:hint="@string/hint_content_body">
-                <requestFocus/>
-            </EditText>
+                android:scrollbars="vertical"
+                android:hint="@string/hint_content_body" />
+
+            <requestFocus/>
 
         </android.support.design.widget.TextInputLayout>
 
         <RelativeLayout
-            android:id="@+id/layout_swich_cw"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/layout_content_body"
-            android:layout_marginTop="10dp">
+            android:id="@+id/layout_content_footer"
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:layout_alignParentBottom="true">
+
+            <ImageView
+                android:id="@+id/attach_image_1"
+                android:layout_width="60dp"
+                android:layout_height="60dp"
+                android:background="@drawable/ic_camera_alt_black_24px"
+                android:backgroundTint="@android:color/darker_gray"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentStart="true" />
 
             <android.support.v7.widget.SwitchCompat
                 android:id="@+id/switch_content_warning"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+                android:layout_height="wrap_content"
+                android:layout_alignBaseline="@+id/label_content_warning"
+                android:layout_alignBottom="@+id/label_content_warning"
+                android:layout_toStartOf="@+id/label_content_warning" />
 
             <TextView
+                android:id="@+id/label_content_warning"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_toEndOf="@+id/switch_content_warning"
-                android:layout_centerVertical="true"
-                android:text="@string/hint_content_warning"/>
+                android:text="@string/label_content_warning"
+                android:layout_alignBaseline="@+id/button_katsu"
+                android:layout_alignBottom="@+id/button_katsu"
+                android:layout_toStartOf="@+id/button_katsu" />
+
+            <Button
+                android:id="@+id/button_katsu"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/Widget.AppCompat.Button.Colored"
+                android:enabled="false"
+                android:text="@string/button_katsu"
+                android:layout_marginLeft="10dp"
+                android:layout_alignParentBottom="true"
+                android:layout_alignParentEnd="true" />
 
         </RelativeLayout>
 
-        <ImageView
-            android:id="@+id/attach_image_1"
-            android:layout_width="60dp"
-            android:layout_height="60dp"
-            android:background="@drawable/ic_camera_alt_black_24px"
-            android:backgroundTint="@android:color/darker_gray"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentStart="true" />
 
-        <Button
-            android:id="@+id/button_katsu"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            style="@style/Widget.AppCompat.Button.Colored"
-            android:enabled="false"
-            android:text="@string/button_katsu"
-            android:layout_alignParentBottom="true"
-            android:layout_alignParentEnd="true" />
+
+
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -82,7 +82,7 @@
             android:layout_height="wrap_content"
             style="@style/Widget.AppCompat.Button.Colored"
             android:enabled="false"
-            android:text="KATSU!"
+            android:text="@string/button_katsu"
             android:layout_alignParentBottom="true"
             android:layout_alignParentEnd="true" />
 

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -40,7 +40,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="top|start"
-                android:hint="@string/hint_content_body"/>
+                android:hint="@string/hint_content_body">
+                <requestFocus/>
+            </EditText>
 
         </android.support.design.widget.TextInputLayout>
 
@@ -69,20 +71,20 @@
             android:id="@+id/attach_image_1"
             android:layout_width="60dp"
             android:layout_height="60dp"
-            android:layout_below="@+id/layout_swich_cw"
-            android:layout_marginTop="10dp"
             android:background="@drawable/ic_camera_alt_black_24px"
-            android:backgroundTint="@android:color/darker_gray"/>
+            android:backgroundTint="@android:color/darker_gray"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentStart="true" />
 
         <Button
             android:id="@+id/button_katsu"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/layout_content_body"
-            android:layout_alignParentEnd="true"
             style="@style/Widget.AppCompat.Button.Colored"
             android:enabled="false"
-            android:text="KATSU!"/>
+            android:text="KATSU!"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="true" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -4,6 +4,7 @@
 
     <string name="hint_content_warning">内容注意メッセージ</string>
     <string name="hint_content_body">今なにしてる？</string>
+    <string name="label_content_warning">内容注意</string>
     <string name="button_katsu">カツ!</string>
     <string name="error_message_5xx">サーバーに繋がらなかった... ＞＜</string>
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -4,6 +4,7 @@
 
     <string name="hint_content_warning">内容注意メッセージ</string>
     <string name="hint_content_body">今なにしてる？</string>
+    <string name="button_katsu">カツ!</string>
     <string name="error_message_5xx">サーバーに繋がらなかった... ＞＜</string>
 
     <string name="push_notification_enabled">アイドルからの通知が届くようになったよ！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 
     <string name="hint_content_warning">Content warning</string>
     <string name="hint_content_body">What is on your mind?</string>
+    <string name="label_content_warning">CW</string>
     <string name="button_katsu">KATSU!</string>
     <string name="error_message_5xx">Server connection error :(</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
 
     <string name="hint_content_warning">Content warning</string>
     <string name="hint_content_body">What is on your mind?</string>
+    <string name="button_katsu">KATSU!</string>
     <string name="error_message_5xx">Server connection error :(</string>
 
     <string name="push_notification_enabled">Push Notification Enabled</string>


### PR DESCRIPTION
# English
Change "KATSU!" activity layout as shown below.
* When screen transition, focus a text area of body and show a keyboard automatically
* "KATSU!" button translate to Japanese in Japanese version
* "KATSU!" button, image insert button and CW switch always show at the bottom of a screen
* Make a text area of body fit to a screen

I have little experience of application development, so feel free to reject if this PR has some problems.

# Japanese
「カツ！」画面に関して以下の変更を行いました。
* 遷移時に本文にフォーカスし、キーボードを自動的に表示
* 「カツ！」ボタンのラベルを日本語版で日本語に変更
* 「カツ！」ボタン、画像ボタン、CWスイッチの位置を常に画面下に表示
*  本文のテキストエリアを画面いっぱいに表示

アプリ開発の経験が殆どないため、問題があれば遠慮なくリジェクトして下さい。

![screenshot_20170503-193133](https://cloud.githubusercontent.com/assets/14988965/25657719/3ca98f46-303a-11e7-86ca-412eb5157422.png)
