### PR TITLE
Multiple image upload

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/ApiStatusDataStore.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/ApiStatusDataStore.kt
@@ -36,8 +36,8 @@ class ApiStatusDataStore(
 
     override fun post(statusForm: StatusForm): Single<Status> {
         val mediaIds: List<String>? =
-                if (statusForm.mediaId != null) {
-                    listOf(statusForm.mediaId.toString())
+                if (statusForm.mediaIds.isNotEmpty()) {
+                    statusForm.mediaIds.map(Int::toString)
                 } else {
                     null
                 }

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/value_object/StatusForm.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/value_object/StatusForm.kt
@@ -3,10 +3,10 @@ package com.bl_lia.kirakiratter.domain.value_object
 data class StatusForm(
         val status: String,
         val inReplyToId: Int? = null,
-        val mediaId: Int? = null,
+        val mediaIds: List<Int> = listOf(),
         val sensitive: Boolean = false,
         val spoilerText: String? = null) {
 
     fun debug(): String =
-        "status: %s, spoilerText: %s, mediaId: %s".format(status, spoilerText, mediaId)
+        "status: %s, spoilerText: %s, mediaId: %s".format(status, spoilerText, mediaIds.joinToString())
 }

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/activity/KatsuActivity.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/activity/KatsuActivity.kt
@@ -25,12 +25,12 @@ class KatsuActivity : AppCompatActivity() {
                 val replyAccountName = intent.getStringExtra(INTENT_PARAM_REPLY_ACCOUNT_NAME)
                 val replyStatusId = intent.getIntExtra(INTENT_PARAM_REPLY_STATUS_ID, -1)
                 val sharedText = intent.getStringExtra(INTENT_PARAM_SHARED_TEXT)
-                val sharedImage = intent.getParcelableExtra<Uri>(INTENT_PARAM_SHARED_IMAGE)
+                val sharedImages = intent.getParcelableArrayListExtra<Uri>(INTENT_PARAM_SHARED_IMAGE) ?: arrayListOf()
                 val fragment = KatsuFragment.newInstance(
                         accountName = replyAccountName,
                         replyStatusId = replyStatusId,
                         sharedText = sharedText,
-                        sharedImage = sharedImage)
+                        sharedImages = sharedImages)
                 transaction.replace(android.R.id.content, fragment)
             }.commit()
         }

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -6,12 +6,12 @@ import android.net.Uri
 import android.os.Bundle
 import android.support.design.widget.Snackbar
 import android.support.v4.app.Fragment
+import android.support.v7.app.AlertDialog
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.TextView
 import com.bl_lia.kirakiratter.App
 import com.bl_lia.kirakiratter.R
@@ -108,14 +108,25 @@ class KatsuFragment : Fragment() {
 
         attachImageViews.forEachIndexed { index, imageView ->
             imageView.setOnClickListener {
-                if (mediaUris.size > index) return@setOnClickListener
-
-                val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                    setType("image/*")
-                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                if (index == mediaUris.size) {
+                    val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                        addCategory(Intent.CATEGORY_OPENABLE)
+                        setType("image/*")
+                        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+                    }
+                    startActivityForResult(intent, REQUEST_PICK_IMAGE)
                 }
-                startActivityForResult(intent, REQUEST_PICK_IMAGE)
+                else if(index < mediaUris.size) {
+                    AlertDialog.Builder(activity)
+                            .setTitle(R.string.cancel_image_dialog_title)
+                            .setMessage(R.string.cancel_image_dialog_message)
+                            .setPositiveButton(android.R.string.yes) { dialog, id ->
+                                removeImageAt(index)
+                                setButtonVisibility()
+                            }
+                            .setNegativeButton(android.R.string.no, null)
+                            .show()
+                }
             }
         }
 
@@ -212,5 +223,17 @@ class KatsuFragment : Fragment() {
                 .centerInside()
                 .onlyScaleDown()
                 .into(imageView)
+    }
+
+    private fun removeImageAt(index:Int) {
+        mediaUris.removeAt(index)
+
+        attachImageViews.subList(index, attachImageViews.size - 1).forEachIndexed { index2, imageView2 ->
+            imageView2.setImageDrawable(attachImageViews[index + index2 + 1].drawable)
+        }
+        attachImageViews[mediaUris.size].apply {
+            setImageDrawable(null)
+            setBackgroundResource(R.drawable.ic_camera_alt_black_24px)
+        }
     }
 }

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -199,6 +199,7 @@ class KatsuFragment : Fragment() {
 
     private fun attachImage(imageUri: Uri) {
         if(mediaUris.size >= attachImageViews.size) {
+            Snackbar.make(layout_content, R.string.post_image_over_max, Snackbar.LENGTH_LONG).show()
             return
         }
 

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -113,6 +113,7 @@ class KatsuFragment : Fragment() {
                 val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
                     addCategory(Intent.CATEGORY_OPENABLE)
                     setType("image/*")
+                    putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
                 }
                 startActivityForResult(intent, REQUEST_PICK_IMAGE)
             }
@@ -159,7 +160,14 @@ class KatsuFragment : Fragment() {
         if (resultCode == Activity.RESULT_OK
                 && requestCode == REQUEST_PICK_IMAGE) {
             data?.let {
-                attachImage(data.data)
+                data.clipData?.let {
+                    (0..data.clipData.itemCount - 1).map { data.clipData.getItemAt(it) }.forEach { item ->
+                        attachImage(item.uri)
+                    }
+                }
+                data.data?.let {
+                    attachImage(data.data)
+                }
             }
             setButtonVisibility()
         }
@@ -199,7 +207,7 @@ class KatsuFragment : Fragment() {
         imageView.setBackgroundResource(0)
         Picasso.with(activity)
                 .load(imageUri)
-                .resize(imageView.width, imageView.height)
+                .resize(attachImageViews[0].width, attachImageViews[0].height) // attachImageViews[0] is always visible
                 .centerInside()
                 .onlyScaleDown()
                 .into(imageView)

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -27,13 +27,13 @@ import javax.inject.Inject
 class KatsuFragment : Fragment() {
 
     companion object {
-        fun newInstance(accountName: String? = null, replyStatusId: Int? = null, sharedText: String? = null, sharedImage: Uri? = null): KatsuFragment =
+        fun newInstance(accountName: String? = null, replyStatusId: Int? = null, sharedText: String? = null, sharedImages: ArrayList<Uri> = arrayListOf()): KatsuFragment =
                 KatsuFragment().also { fragment ->
                     val bundle = Bundle().apply {
                         if (!accountName.isNullOrEmpty()) putString(PARAM_ACCOUNT_NAME, accountName)
                         if (replyStatusId != null && replyStatusId > -1) putInt(PARAM_REPLY_STATUS_ID, replyStatusId)
                         putString(PARAM_SHARED_TEXT, sharedText)
-                        putParcelable(PARAM_SHARED_IMAGE, sharedImage)
+                        putParcelableArrayList(PARAM_SHARED_IMAGE, sharedImages)
                     }
                     fragment.arguments = bundle
                 }
@@ -158,7 +158,7 @@ class KatsuFragment : Fragment() {
         }
 
         if (arguments.containsKey(PARAM_SHARED_IMAGE)) {
-            arguments.getParcelable<Uri>(PARAM_SHARED_IMAGE)?.let { sharedImage ->
+            arguments.getParcelableArrayList<Uri>(PARAM_SHARED_IMAGE)?.forEach { sharedImage ->
                 attachImage(sharedImage)
             }
         }
@@ -219,7 +219,8 @@ class KatsuFragment : Fragment() {
         imageView.setBackgroundResource(0)
         Picasso.with(activity)
                 .load(imageUri)
-                .resize(attachImageViews[0].width, attachImageViews[0].height) // attachImageViews[0] is always visible
+                .resize(resources.getDimensionPixelSize(R.dimen.katsu_image_width),
+                        resources.getDimensionPixelSize(R.dimen.katsu_image_height))
                 .centerInside()
                 .onlyScaleDown()
                 .into(imageView)

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/MainFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/MainFragment.kt
@@ -44,12 +44,15 @@ class MainFragment : Fragment() {
         }
     }
 
-    private val sharedImage: Uri? by lazy {
+    private val sharedImages: ArrayList<Uri> by lazy {
         if (activity.intent.action == Intent.ACTION_SEND
                 && activity.intent.type.startsWith("image/")) {
-            activity.intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
+            activity.intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.let { arrayListOf(it) } ?: arrayListOf()
+        } else if(activity.intent.action == Intent.ACTION_SEND_MULTIPLE
+                && activity.intent.type.startsWith("image/")) {
+            ArrayList(activity.intent.getParcelableArrayListExtra<Uri>(Intent.EXTRA_STREAM).orEmpty())
         } else {
-            null
+            arrayListOf()
         }
     }
 
@@ -88,11 +91,11 @@ class MainFragment : Fragment() {
                 .subscribe { authenticated ->
                     if (authenticated) {
                         if (activity != null) {
-                            if (sharedText != null || sharedImage != null) {
+                            if (sharedText != null || sharedImages.isNotEmpty()) {
                                 val intent = Intent(activity, KatsuActivity::class.java).apply {
                                     setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                                     putExtra(KatsuActivity.INTENT_PARAM_SHARED_TEXT, sharedText)
-                                    putExtra(KatsuActivity.INTENT_PARAM_SHARED_IMAGE, sharedImage)
+                                    putParcelableArrayListExtra(KatsuActivity.INTENT_PARAM_SHARED_IMAGE, sharedImages)
                                 }
                                 startActivity(intent)
                             } else {

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/presenter/KatsuPresenter.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/presenter/KatsuPresenter.kt
@@ -35,16 +35,17 @@ class KatsuPresenter
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
-    fun post(text: String, warning: String? = null, inReplyToId: Int? = null, sensitive: Boolean = false, attachment: Uri? = null): Single<Status> {
+    fun post(text: String, warning: String? = null, inReplyToId: Int? = null, sensitive: Boolean = false, attachment: List<Uri> = listOf()): Single<Status> {
 
-        if (attachment != null) {
-            return uploadMedia.execute(attachment)
-                    .flatMap { media ->
+        if (attachment.isNotEmpty()) {
+            return Single.concat(attachment.map { uploadMedia.execute(it) })
+                    .toList()
+                    .flatMap { medias ->
                         postStatus.execute(StatusForm(
                                 status = text,
                                 spoilerText = warning,
                                 inReplyToId = inReplyToId,
-                                mediaId = media.id
+                                mediaIds = medias.map { it.id }
                         ))
                     }
         } else {

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -42,7 +42,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_below="@+id/layout_content_header"
-            android:layout_above="@+id/layout_content_footer">
+            android:layout_above="@+id/layout_image_list_container">
 
             <EditText
                 android:id="@+id/katsu_content_body"
@@ -56,6 +56,20 @@
 
         </android.support.design.widget.TextInputLayout>
 
+        <HorizontalScrollView
+            android:id="@+id/layout_image_list_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_above="@+id/layout_content_footer">
+
+            <LinearLayout
+                android:id="@+id/attach_image_list"
+                android:orientation="horizontal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </HorizontalScrollView>
+
         <RelativeLayout
             android:id="@+id/layout_content_footer"
             android:layout_width="match_parent"
@@ -64,39 +78,12 @@
 
             <ImageView
                 android:id="@+id/attach_image_1"
-                android:layout_width="@dimen/katsu_image_width"
-                android:layout_height="@dimen/katsu_image_height"
+                android:layout_width="60dp"
+                android:layout_height="60dp"
                 android:background="@drawable/ic_camera_alt_black_24px"
                 android:backgroundTint="@android:color/darker_gray"
                 android:layout_alignParentBottom="true"
                 android:layout_alignParentStart="true" />
-
-            <ImageView
-                android:id="@+id/attach_image_2"
-                android:layout_width="@dimen/katsu_image_width"
-                android:layout_height="@dimen/katsu_image_height"
-                android:layout_alignTop="@+id/attach_image_1"
-                android:layout_toEndOf="@+id/attach_image_1"
-                android:background="@drawable/ic_camera_alt_black_24px"
-                android:backgroundTint="@android:color/darker_gray"/>
-
-            <ImageView
-                android:id="@+id/attach_image_3"
-                android:layout_width="@dimen/katsu_image_width"
-                android:layout_height="@dimen/katsu_image_height"
-                android:layout_alignTop="@+id/attach_image_1"
-                android:layout_toEndOf="@+id/attach_image_2"
-                android:background="@drawable/ic_camera_alt_black_24px"
-                android:backgroundTint="@android:color/darker_gray"/>
-
-            <ImageView
-                android:id="@+id/attach_image_4"
-                android:layout_width="@dimen/katsu_image_width"
-                android:layout_height="@dimen/katsu_image_height"
-                android:layout_alignTop="@+id/attach_image_1"
-                android:layout_toEndOf="@+id/attach_image_3"
-                android:background="@drawable/ic_camera_alt_black_24px"
-                android:backgroundTint="@android:color/darker_gray"/>
 
             <android.support.v7.widget.SwitchCompat
                 android:id="@+id/switch_content_warning"

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -64,8 +64,8 @@
 
             <ImageView
                 android:id="@+id/attach_image_1"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
+                android:layout_width="@dimen/katsu_image_width"
+                android:layout_height="@dimen/katsu_image_height"
                 android:background="@drawable/ic_camera_alt_black_24px"
                 android:backgroundTint="@android:color/darker_gray"
                 android:layout_alignParentBottom="true"
@@ -73,8 +73,8 @@
 
             <ImageView
                 android:id="@+id/attach_image_2"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
+                android:layout_width="@dimen/katsu_image_width"
+                android:layout_height="@dimen/katsu_image_height"
                 android:layout_alignTop="@+id/attach_image_1"
                 android:layout_toEndOf="@+id/attach_image_1"
                 android:background="@drawable/ic_camera_alt_black_24px"
@@ -82,8 +82,8 @@
 
             <ImageView
                 android:id="@+id/attach_image_3"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
+                android:layout_width="@dimen/katsu_image_width"
+                android:layout_height="@dimen/katsu_image_height"
                 android:layout_alignTop="@+id/attach_image_1"
                 android:layout_toEndOf="@+id/attach_image_2"
                 android:background="@drawable/ic_camera_alt_black_24px"
@@ -91,8 +91,8 @@
 
             <ImageView
                 android:id="@+id/attach_image_4"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
+                android:layout_width="@dimen/katsu_image_width"
+                android:layout_height="@dimen/katsu_image_height"
                 android:layout_alignTop="@+id/attach_image_1"
                 android:layout_toEndOf="@+id/attach_image_3"
                 android:background="@drawable/ic_camera_alt_black_24px"

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -71,6 +71,33 @@
                 android:layout_alignParentBottom="true"
                 android:layout_alignParentStart="true" />
 
+            <ImageView
+                android:id="@+id/attach_image_2"
+                android:layout_width="60dp"
+                android:layout_height="60dp"
+                android:layout_alignTop="@+id/attach_image_1"
+                android:layout_toEndOf="@+id/attach_image_1"
+                android:background="@drawable/ic_camera_alt_black_24px"
+                android:backgroundTint="@android:color/darker_gray"/>
+
+            <ImageView
+                android:id="@+id/attach_image_3"
+                android:layout_width="60dp"
+                android:layout_height="60dp"
+                android:layout_alignTop="@+id/attach_image_1"
+                android:layout_toEndOf="@+id/attach_image_2"
+                android:background="@drawable/ic_camera_alt_black_24px"
+                android:backgroundTint="@android:color/darker_gray"/>
+
+            <ImageView
+                android:id="@+id/attach_image_4"
+                android:layout_width="60dp"
+                android:layout_height="60dp"
+                android:layout_alignTop="@+id/attach_image_1"
+                android:layout_toEndOf="@+id/attach_image_3"
+                android:background="@drawable/ic_camera_alt_black_24px"
+                android:backgroundTint="@android:color/darker_gray"/>
+
             <android.support.v7.widget.SwitchCompat
                 android:id="@+id/switch_content_warning"
                 android:layout_width="wrap_content"

--- a/app/src/main/res/layout/list_item_katsu_image.xml
+++ b/app/src/main/res/layout/list_item_katsu_image.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content" >
+
+    <ImageView
+        android:id="@+id/attach_image_content"
+        android:layout_width="160dp"
+        android:layout_height="160dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp" />
+
+    <ImageView
+        android:id="@+id/attach_image_remove"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@id/attach_image_content"
+        android:layout_alignEnd="@id/attach_image_content"
+        android:src="@android:drawable/ic_menu_close_clear_cancel" />
+
+</RelativeLayout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -17,6 +17,4 @@
 
     <string name="timeline_boosted">%s さんがブースト</string>
     <string name="post_image_over_max">画像は4個までだよ</string>
-    <string name="cancel_image_dialog_title">画像選択</string>
-    <string name="cancel_image_dialog_message">この画像の選択を取り消す？</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -17,4 +17,6 @@
 
     <string name="timeline_boosted">%s さんがブースト</string>
     <string name="post_image_over_max">画像は4個までだよ</string>
+    <string name="cancel_image_dialog_title">画像選択</string>
+    <string name="cancel_image_dialog_message">この画像の選択を取り消す？</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -16,4 +16,5 @@
     <string name="notification_mention">%s さんがコメントくれたよ</string>
 
     <string name="timeline_boosted">%s さんがブースト</string>
+    <string name="post_image_over_max">画像は4個までだよ</string>
 </resources>

--- a/app/src/main/res/values/dimentions.xml
+++ b/app/src/main/res/values/dimentions.xml
@@ -14,7 +14,4 @@
     <dimen name="font_size_toot_time">12sp</dimen>
 
     <dimen name="avatar_size">60dp</dimen>
-
-    <dimen name="katsu_image_width">60dp</dimen>
-    <dimen name="katsu_image_height">60dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimentions.xml
+++ b/app/src/main/res/values/dimentions.xml
@@ -14,4 +14,7 @@
     <dimen name="font_size_toot_time">12sp</dimen>
 
     <dimen name="avatar_size">60dp</dimen>
+
+    <dimen name="katsu_image_width">60dp</dimen>
+    <dimen name="katsu_image_height">60dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
     <string name="notification_mention">%s mentioned you</string>
 
     <string name="timeline_boosted">%s boosted</string>
+    <string name="post_image_over_max">Maximum number of images is 4.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,4 @@
 
     <string name="timeline_boosted">%s boosted</string>
     <string name="post_image_over_max">Maximum number of images is 4.</string>
-    <string name="cancel_image_dialog_title">Image selection</string>
-    <string name="cancel_image_dialog_message">Cancel this image?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
 
     <string name="timeline_boosted">%s boosted</string>
     <string name="post_image_over_max">Maximum number of images is 4.</string>
+    <string name="cancel_image_dialog_title">Image selection</string>
+    <string name="cancel_image_dialog_message">Cancel this image?</string>
 </resources>


### PR DESCRIPTION
# 複数画像アップロード機能の追加
## 変更内容
- 投稿画面で複数画像を選択・表示できるように変更
- 選択した複数画像のアップロードと、投稿データ内容に複数画像の反映
- 他アプリからの `ACTION_SEND_MULTIPLE` を受け入れるように変更

## 不足していそうな部分
- 画像の選択解除する❌ボタンアイコン
  - ひとまず `@android:drawable/ic_menu_close_clear_cancel` を表示していますが、適切なアイコンがあれば差し替えたほうがよさそうです
- 画像追加する📷ボタンアイコン
  - 画像を最大数選択済みの時でもボタンの見た目が変わらないので、無効状態かどうかわかるようにした方がいいのかもしれません
- アップロード中の表示
  - アップロードの通信中もUI操作できてしまうので、通信中のダイアログか何かを出した方がよさそうです