### PR TITLE
scroll top when tap left of toolbar

### DIFF
--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/activity/TimelineActivity.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/activity/TimelineActivity.kt
@@ -103,7 +103,7 @@ class TimelineActivity : AppCompatActivity() {
                     }
         }
 
-        banner_toolbar.setOnClickListener {
+        toolbar_space_left.setOnClickListener {
             val innerFragment = timelineFragmentAdapter.getItem(view_pager.currentItem)
             if(innerFragment is ScrollableFragment) {
                 innerFragment.scrollToTop()

--- a/app/src/main/res/layout/activity_timeline.xml
+++ b/app/src/main/res/layout/activity_timeline.xml
@@ -70,6 +70,13 @@
                     android:layout_gravity="end"
                     android:background="@drawable/ic_home_kira_18px"/>
 
+                <View
+                    android:id="@+id/toolbar_space_left"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="end"
+                    android:background="@android:color/transparent"/>
+
             </android.support.v7.widget.Toolbar>
 
             <!--<FrameLayout-->


### PR DESCRIPTION
Xperia Z5 Compactのような、toolbarのリボンとhome/localのアイコンが重なってしまう端末だとhome/local切り替えのボタンが押せなくなってしまうことに気付いたので、取り急ぎtoolbarの左側の余白をタップすると一番上に戻るようにしました