### PR TITLE
カツ！画面のレイアウト修正

### DIFF
--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -1,6 +1,7 @@
 package com.bl_lia.kirakiratter.presentation.fragment
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -11,6 +12,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import com.bl_lia.kirakiratter.App
 import com.bl_lia.kirakiratter.R
@@ -126,6 +128,12 @@ class KatsuFragment : Fragment() {
                 setKatsuButtonVisibility()
             }
         })
+
+        layout_content_scroll.onClickOutsideListener = {
+            katsu_content_body.requestFocus()
+            (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).showSoftInput(katsu_content_body, 0)
+        }
+        layout_image_list_container.onClickOutsideListener = layout_content_scroll.onClickOutsideListener
 
         if (arguments.containsKey(PARAM_ACCOUNT_NAME)) {
             val accountText = "@%s ".format(arguments.getString(PARAM_ACCOUNT_NAME))

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/view/OutsideClickableHorizontalScrollView.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/view/OutsideClickableHorizontalScrollView.kt
@@ -1,0 +1,26 @@
+package com.bl_lia.kirakiratter.presentation.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.widget.HorizontalScrollView
+
+class OutsideClickableHorizontalScrollView @JvmOverloads constructor(
+        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : HorizontalScrollView(context, attrs, defStyleAttr) {
+
+    var onClickOutsideListener: (() -> Unit)? = null
+
+    override fun onTouchEvent(ev: MotionEvent?): Boolean {
+        if(ev?.actionMasked == MotionEvent.ACTION_UP) {
+            val isOutside =
+                    if(childCount == 0) true
+                    else getChildAt(0).let { child -> ev.x + scrollX < child.left || ev.x + scrollX > child.right }
+            if(isOutside) {
+                post { onClickOutsideListener?.invoke() }
+            }
+        }
+
+        return super.onTouchEvent(ev)
+    }
+}

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/view/OutsideClickableScrollView.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/view/OutsideClickableScrollView.kt
@@ -1,0 +1,26 @@
+package com.bl_lia.kirakiratter.presentation.view
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.widget.ScrollView
+
+class OutsideClickableScrollView @JvmOverloads constructor(
+        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : ScrollView(context, attrs, defStyleAttr) {
+
+    var onClickOutsideListener: (() -> Unit)? = null
+
+    override fun onTouchEvent(ev: MotionEvent?): Boolean {
+        if(ev?.actionMasked == MotionEvent.ACTION_UP) {
+            val isOutside =
+                    if(childCount == 0) true
+                    else getChildAt(0).let { child -> ev.y + scrollY < child.top || ev.y + scrollY > child.bottom }
+            if(isOutside) {
+                post { onClickOutsideListener?.invoke() }
+            }
+        }
+
+        return super.onTouchEvent(ev)
+    }
+}

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -14,61 +14,76 @@
         android:padding="10dp"
         android:background="@color/timeline_bg">
 
-        <RelativeLayout
-            android:id="@+id/layout_content_header"
+        <ScrollView
+            android:id="@+id/layout_content_scroll"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentTop="true">
-
-            <android.support.design.widget.TextInputLayout
-                android:id="@+id/content_warning_textinput"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                tools:visibility="visible">
-
-                <EditText
-                    android:id="@+id/content_warning_edittext"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/hint_content_warning"/>
-
-            </android.support.design.widget.TextInputLayout>
-
-        </RelativeLayout>
-
-        <android.support.design.widget.TextInputLayout
-            android:id="@+id/layout_content_body"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/layout_content_header"
-            android:layout_above="@+id/layout_image_list_container">
-
-            <EditText
-                android:id="@+id/katsu_content_body"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:gravity="top|start"
-                android:scrollbars="vertical"
-                android:hint="@string/hint_content_body" />
-
-            <requestFocus/>
-
-        </android.support.design.widget.TextInputLayout>
-
-        <HorizontalScrollView
-            android:id="@+id/layout_image_list_container"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
             android:layout_above="@+id/layout_content_footer">
 
-            <LinearLayout
-                android:id="@+id/attach_image_list"
-                android:orientation="horizontal"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content" />
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-        </HorizontalScrollView>
+                <RelativeLayout
+                    android:id="@+id/layout_content_header"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true">
+
+                    <android.support.design.widget.TextInputLayout
+                        android:id="@+id/content_warning_textinput"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        tools:visibility="visible">
+
+                        <EditText
+                            android:id="@+id/content_warning_edittext"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/hint_content_warning"/>
+
+                    </android.support.design.widget.TextInputLayout>
+
+                </RelativeLayout>
+
+                <android.support.design.widget.TextInputLayout
+                    android:id="@+id/layout_content_body"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/layout_content_header">
+
+                    <EditText
+                        android:id="@+id/katsu_content_body"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:gravity="top|start"
+                        android:scrollbars="vertical"
+                        android:hint="@string/hint_content_body" />
+
+                    <requestFocus/>
+
+                </android.support.design.widget.TextInputLayout>
+
+                <HorizontalScrollView
+                    android:id="@+id/layout_image_list_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/layout_content_body"
+                    android:layout_alignParentBottom="true">
+
+                    <LinearLayout
+                        android:id="@+id/attach_image_list"
+                        android:orientation="horizontal"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                </HorizontalScrollView>
+
+            </RelativeLayout>
+
+        </ScrollView>
 
         <RelativeLayout
             android:id="@+id/layout_content_footer"

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -14,7 +14,7 @@
         android:padding="10dp"
         android:background="@color/timeline_bg">
 
-        <ScrollView
+        <com.bl_lia.kirakiratter.presentation.view.OutsideClickableScrollView
             android:id="@+id/layout_content_scroll"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -66,7 +66,7 @@
 
                 </android.support.design.widget.TextInputLayout>
 
-                <HorizontalScrollView
+                <com.bl_lia.kirakiratter.presentation.view.OutsideClickableHorizontalScrollView
                     android:id="@+id/layout_image_list_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -79,11 +79,11 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
 
-                </HorizontalScrollView>
+                </com.bl_lia.kirakiratter.presentation.view.OutsideClickableHorizontalScrollView>
 
             </RelativeLayout>
 
-        </ScrollView>
+        </com.bl_lia.kirakiratter.presentation.view.OutsideClickableScrollView>
 
         <RelativeLayout
             android:id="@+id/layout_content_footer"


### PR DESCRIPTION
テキスト入力とプレビュー画像部分を `ScrollView` に包む変更を追加。

画像選択してプレビュー画像表示中にCW ON＋ソフトキーボード表示するなど、
画面の高さが足りなくなるとテキスト入力欄が潰れてしまっていたので、
全体がスクロールするように修正。
これによりテキスト入力欄の高さが以前と同様に戻ってしまうので、
下部ボタン列との間の空いている部分をタップしてもテキスト入力欄にフォーカスが行くように変更。
（Twitter公式アプリの投稿画面とほぼ同様の挙動。）