### PR TITLE
カツ！画面で画面回転時に選択画像を保持

### DIFF
--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -43,13 +43,14 @@ class KatsuFragment : Fragment() {
         private val PARAM_REPLY_STATUS_ID = "param_reply_status_id"
         private val PARAM_SHARED_TEXT = "param_shared_text"
         private val PARAM_SHARED_IMAGE = "param_shared_image"
+        private val PARAM_SAVED_IMAGE = "param_saved_image"
         private val MAX_IMAGE_COUNT = 4
     }
 
     @Inject
     lateinit var presenter: KatsuPresenter
 
-    val mediaUris = mutableListOf<Uri>()
+    val mediaUris = ArrayList<Uri>()
 
     private val component: StatusComponent by lazy {
         DaggerStatusComponent.builder()
@@ -142,13 +143,24 @@ class KatsuFragment : Fragment() {
             }
         }
 
-        if (arguments.containsKey(PARAM_SHARED_IMAGE)) {
+        if(savedInstanceState != null && savedInstanceState.containsKey(PARAM_SAVED_IMAGE)) {
+            savedInstanceState.getParcelableArrayList<Uri>(PARAM_SAVED_IMAGE)?.forEach { sharedImage ->
+                attachImage(sharedImage)
+            }
+        }
+        else if (arguments.containsKey(PARAM_SHARED_IMAGE)) {
             arguments.getParcelableArrayList<Uri>(PARAM_SHARED_IMAGE)?.forEach { sharedImage ->
                 attachImage(sharedImage)
             }
         }
 
         setKatsuButtonVisibility()
+    }
+
+    override fun onSaveInstanceState(outState: Bundle?) {
+        outState?.putParcelableArrayList(PARAM_SAVED_IMAGE, mediaUris)
+
+        super.onSaveInstanceState(outState)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
画面を縦横回転しても選択した画像が保持されるように変更。