### PR TITLE
add visibility select and change reblog action

### DIFF
--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/StatusDataRepository.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/StatusDataRepository.kt
@@ -16,8 +16,8 @@ class StatusDataRepository
             private val statusDataStoreFactory: StatusDataStoreFactory
     ): StatusRepository {
 
-    override fun post(text: String, warning: String?, sensitive: Boolean?, mediaId: String?): Single<Status> =
-            statusDataStoreFactory.create().post(text, warning, sensitive, mediaId)
+    override fun post(text: String, warning: String?, inReplyToId: Int?, sensitive: Boolean?, visibility: String?, mediaId: String?): Single<Status> =
+            statusDataStoreFactory.create().post(text, warning, inReplyToId, sensitive, visibility, mediaId)
 
     override fun post(statusForm: StatusForm): Single<Status> =
             statusDataStoreFactory.create().post(statusForm)

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/ApiStatusDataStore.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/ApiStatusDataStore.kt
@@ -18,7 +18,7 @@ class ApiStatusDataStore(
         private val statusService: StatusService
 ) : StatusDataStore {
 
-    override fun post(text: String, warning: String?, sensitive: Boolean?, mediaId: String?): Single<Status> {
+    override fun post(text: String, warning: String?, inReplyToId: Int?, sensitive: Boolean?, visibility: String?, mediaId: String?): Single<Status> {
         val mediaIds: List<String>? =
             if (mediaId != null) {
                 listOf(mediaId)
@@ -29,7 +29,9 @@ class ApiStatusDataStore(
         return statusService.post(
                 text = text,
                 warning = warning,
+                inReplyToId = inReplyToId,
                 sensitive = sensitive,
+                visibility = visibility,
                 mediaIds = mediaIds
         )
     }
@@ -45,8 +47,9 @@ class ApiStatusDataStore(
         return statusService.post(
                 text = statusForm.status,
                 warning = statusForm.spoilerText,
-                inReplyTo = statusForm.inReplyToId,
+                inReplyToId = statusForm.inReplyToId,
                 sensitive = statusForm.sensitive,
+                visibility = statusForm.visibility,
                 mediaIds = mediaIds
         )
     }

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/StatusDataStore.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/StatusDataStore.kt
@@ -11,7 +11,9 @@ interface StatusDataStore {
     fun post(
             text: String,
             warning: String? = null,
+            inReplyToId: Int? = null,
             sensitive: Boolean? = null,
+            visibility: String? = null,
             mediaId: String? = null
     ): Single<Status>
 

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/StatusService.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/data/repository/datasource/status/StatusService.kt
@@ -16,9 +16,11 @@ interface StatusService {
             @Field("spoiler_text")
             warning: String? = null,
             @Field("in_reply_to_id")
-            inReplyTo: Int? = null,
+            inReplyToId: Int? = null,
             @Field("sensitive")
             sensitive: Boolean? = null,
+            @Field("visibility")
+            visibility: String? = null,
             @Field("media_ids[]")
             mediaIds: List<String>? = null
     ): Single<Status>

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/data/type_adapter/StatusTypeAdapter.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/data/type_adapter/StatusTypeAdapter.kt
@@ -31,6 +31,7 @@ class StatusTypeAdapter : TypeAdapter<Status>() {
         var favourited: Boolean = false
         var mediaAttachments: List<Media>? = null
         var sensitive: Boolean = false
+        var visibility: String? = null
         var createdAt: Date? = null
         var url: String? = null
 
@@ -57,6 +58,7 @@ class StatusTypeAdapter : TypeAdapter<Status>() {
                 "reblogged" -> reblogged = input.nextBooleanExtra(false)
                 "media_attachments" -> mediaAttachments = input.mediaList()
                 "sensitive" -> sensitive = input.nextBooleanExtra(false)
+                "visibility" -> visibility = input.nextStringExtra()
                 "created_at" -> createdAt = DateTime.parse(input.nextString()).toDate()
                 "url" -> url = input.nextStringExtra()
                 else -> input.skipValue()
@@ -75,6 +77,7 @@ class StatusTypeAdapter : TypeAdapter<Status>() {
                 favourited = favourited,
                 mediaAttachments = mediaAttachments ?: listOf(),
                 sensitive = sensitive,
+                visibility = visibility,
                 createdAt = createdAt,
                 url = url)
     }
@@ -94,6 +97,7 @@ class StatusTypeAdapter : TypeAdapter<Status>() {
         var reblogged: Boolean = false
         var mediaAttachments: List<Media>? = null
         var sensitive: Boolean = false
+        var visibility: String? = null
         var createdAt: Date? = null
         var url: String? = null
 
@@ -114,6 +118,7 @@ class StatusTypeAdapter : TypeAdapter<Status>() {
                 "reblogged" -> reblogged = nextBooleanExtra(false)
                 "media_attachments" -> mediaAttachments = mediaList()
                 "sensitive" -> sensitive = nextBooleanExtra(false)
+                "visibility" -> visibility = nextStringExtra()
                 "created_at" -> createdAt = DateTime.parse(nextStringExtra()).toDate()
                 "url" -> url = nextStringExtra()
                 else -> skipValue()
@@ -131,6 +136,7 @@ class StatusTypeAdapter : TypeAdapter<Status>() {
                 favourited = favourited,
                 mediaAttachments = mediaAttachments ?: listOf(),
                 sensitive = sensitive,
+                visibility = visibility,
                 createdAt = createdAt,
                 url = url)
     }

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/entity/Status.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/entity/Status.kt
@@ -17,6 +17,7 @@ data class Status(
         val favourited: Boolean,
         val mediaAttachments: List<Media> = listOf(),
         val sensitive: Boolean = false,
+        val visibility: String? = null,
         val createdAt: Date? = null,
         val url: String?
 ) {
@@ -33,6 +34,7 @@ data class Status(
                     reblogged = reblogged,
                     favourited = favourited,
                     sensitive = sensitive,
+                    visibility = visibility,
                     createdAt = createdAt,
                     url = url
             ).also { realmStatus ->

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/entity/realm/RealmStatus.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/entity/realm/RealmStatus.kt
@@ -16,6 +16,7 @@ open class RealmStatus(
         open var favourited: Boolean = false,
         open var mediaAttachments: RealmList<RealmMedia> = RealmList(),
         open var sensitive: Boolean = false,
+        open var visibility: String? = null,
         open var createdAt: Date? = null,
         open var url: String? = null
 ): RealmObject() {
@@ -30,6 +31,7 @@ open class RealmStatus(
                     favourited = favourited,
                     mediaAttachments = mediaAttachments.map { it.toMedia() },
                     sensitive = sensitive,
+                    visibility = visibility,
                     createdAt = createdAt,
                     url = url
             )

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/interactor/status/PostStatusUseCase.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/interactor/status/PostStatusUseCase.kt
@@ -29,18 +29,20 @@ class PostStatusUseCase(
     private fun postParam(params: Array<out Any>): Single<Status> {
         val text = params[0] as String
         val warning = params[1] as String
-        val sensitive = params[2] as Boolean
-        if (params.size > 3) {
-            val mediaId: Int? = params[3] as Int?
+        val inReplyToId = params[2] as Int
+        val sensitive = params[3] as Boolean
+        val visibility = params[4] as String
+        if (params.size > 5) {
+            val mediaId: Int? = params[5] as Int?
             val mediaIdString: String? =
                     if (mediaId != null) {
                         mediaId.toString()
                     } else {
                         null
                     }
-            return statusRepository.post(text, warning, sensitive, mediaIdString)
+            return statusRepository.post(text, warning, inReplyToId, sensitive, visibility, mediaIdString)
         } else {
-            return statusRepository.post(text, warning, sensitive)
+            return statusRepository.post(text, warning, inReplyToId, sensitive, visibility)
         }
     }
 }

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/repository/StatusRepository.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/repository/StatusRepository.kt
@@ -11,7 +11,9 @@ interface StatusRepository {
     fun post(
             text: String,
             warning: String? = null,
+            inReplyToId: Int? = null,
             sensitive: Boolean? = null,
+            visibility: String? = null,
             mediaId: String? = null
     ): Single<Status>
 

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/value_object/StatusForm.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/domain/value_object/StatusForm.kt
@@ -5,7 +5,8 @@ data class StatusForm(
         val inReplyToId: Int? = null,
         val mediaIds: List<Int> = listOf(),
         val sensitive: Boolean = false,
-        val spoilerText: String? = null) {
+        val spoilerText: String? = null,
+        val visibility: String? = null) {
 
     fun debug(): String =
         "status: %s, spoilerText: %s, mediaId: %s".format(status, spoilerText, mediaIds.joinToString())

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/adapter/timeline/TimelineItemViewHolder.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/adapter/timeline/TimelineItemViewHolder.kt
@@ -181,12 +181,18 @@ class TimelineItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
     }
 
     private fun initActions(status: Status) {
+        val visibility = status.visibility
+
         reblogButton.background =
-                if (status.reblogged) {
-                    ContextCompat.getDrawable(itemView.context, R.drawable.ic_reblog_reblog)
-                } else {
-                    ContextCompat.getDrawable(itemView.context, R.drawable.ic_reblog_unreblog)
-                }
+            if (visibility == "direct") {
+                ContextCompat.getDrawable(itemView.context, R.drawable.ic_reblog_direct)
+            } else if (visibility == "private") {
+                ContextCompat.getDrawable(itemView.context, R.drawable.ic_reblog_private)
+            } else if (status.reblogged) {
+                ContextCompat.getDrawable(itemView.context, R.drawable.ic_reblog_reblog)
+            } else {
+                ContextCompat.getDrawable(itemView.context, R.drawable.ic_reblog_unreblog)
+            }
 
         favouriteButton.background =
                 if (status.favourited) {

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/AccountFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/AccountFragment.kt
@@ -117,17 +117,19 @@ class AccountFragment : RxFragment() {
         }
         adapter.onClickReblog.subscribe { status ->
             val target = status.reblog ?: status
-            presenter.reblog(target)
-                    .compose(bindToLifecycle())
-                    .subscribe { status, error ->
-                        if (error != null) {
-                            showError(error)
-                            return@subscribe
-                        }
+            if (target.visibility == "public" || target.visibility == "unlisted") {
+                presenter.reblog(target)
+                        .compose(bindToLifecycle())
+                        .subscribe { status, error ->
+                            if (error != null) {
+                                showError(error)
+                                return@subscribe
+                            }
 
-                        val updateTarget = status.reblog ?: status
-                        adapter.update(updateTarget)
-                    }
+                            val updateTarget = status.reblog ?: status
+                            adapter.update(updateTarget)
+                        }
+            }
         }
         adapter.onClickFavourite.subscribe { status ->
             val target = status.reblog ?: status

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/KatsuFragment.kt
@@ -9,10 +9,13 @@ import android.support.design.widget.Snackbar
 import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
+import android.widget.PopupMenu
 import android.widget.TextView
+import android.widget.Toast
 import com.bl_lia.kirakiratter.App
 import com.bl_lia.kirakiratter.R
 import com.bl_lia.kirakiratter.domain.extension.preparedErrorMessage
@@ -54,6 +57,8 @@ class KatsuFragment : RxFragment() {
     lateinit var presenter: KatsuPresenter
 
     val mediaUris = ArrayList<Uri>()
+    val visibility = arrayOf("public", "unlisted", "private", "direct")
+    var vindex = 0
 
     private val component: StatusComponent by lazy {
         DaggerStatusComponent.builder()
@@ -73,6 +78,15 @@ class KatsuFragment : RxFragment() {
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val visibilityListener = View.OnClickListener { it ->
+            when (it.id) {
+                R.id.visibility_menu -> {
+                    showPopup(it)
+                }
+            }
+        }
+        visibility_menu.setOnClickListener(visibilityListener)
+
         button_katsu.setOnClickListener {
             val header = content_warning_edittext.text.toString()
             val body = katsu_content_body.text.toString()
@@ -91,7 +105,8 @@ class KatsuFragment : RxFragment() {
                         warning = header,
                         attachment = mediaUris,
                         sensitive = nsfw,
-                        inReplyToId = replyTo)
+                        inReplyToId = replyTo,
+                        visibility = visibility[vindex])
                         .compose(bindToLifecycle())
                         .subscribe { status, error ->
                             button_katsu.isEnabled = true
@@ -191,6 +206,40 @@ class KatsuFragment : RxFragment() {
             }
             setKatsuButtonVisibility()
         }
+    }
+
+    private fun showPopup(view: View) {
+        var popup: PopupMenu?
+        popup = PopupMenu(this.context, view)
+        popup.inflate(R.menu.menu_visibility)
+
+        popup.setOnMenuItemClickListener(PopupMenu.OnMenuItemClickListener { item: MenuItem? ->
+            when (item!!.itemId) {
+                R.id.menu_public -> {
+                    visibility_menu.setBackgroundResource(R.drawable.ic_public_black_24dp)
+                    Toast.makeText(this.context, item.title, Toast.LENGTH_SHORT).show()
+                    vindex = 0
+                }
+                R.id.menu_unlisted -> {
+                    visibility_menu.setBackgroundResource(R.drawable.ic_lock_open_black_24dp)
+                    Toast.makeText(this.context, item.title, Toast.LENGTH_SHORT).show()
+                    vindex = 1
+                }
+                R.id.menu_private -> {
+                    visibility_menu.setBackgroundResource(R.drawable.ic_lock_outline_black_24dp)
+                    Toast.makeText(this.context, item.title, Toast.LENGTH_SHORT).show()
+                    vindex = 2
+                }
+                R.id.menu_direct -> {
+                    visibility_menu.setBackgroundResource(R.drawable.ic_email_black_24dp)
+                    Toast.makeText(this.context, item.title, Toast.LENGTH_SHORT).show()
+                    vindex = 3
+                }
+            }
+            true
+        })
+
+        popup.show()
     }
 
     private fun setHint() {

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/TimelineFragment.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/fragment/TimelineFragment.kt
@@ -121,17 +121,19 @@ class TimelineFragment : RxFragment(), ScrollableFragment {
             startActivity(intent)
         }
         adapter.onClickReblog.subscribe { status ->
-            presenter.reblog(status)
-                    .subscribe { status, error ->
-                        if (error != null) {
-                            showError(error)
-                            return@subscribe
-                        }
+            if (status.visibility == "public" || status.visibility == "unlisted") {
+                presenter.reblog(status)
+                        .subscribe { status, error ->
+                            if (error != null) {
+                                showError(error)
+                                return@subscribe
+                            }
 
-                        status.reblog?.let {
-                            adapter.update(it)
+                            status.reblog?.let {
+                                adapter.update(it)
+                            }
                         }
-                    }
+            }
         }
         adapter.onClickFavourite.subscribe { status ->
             presenter.favourite(status)

--- a/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/presenter/KatsuPresenter.kt
+++ b/app/src/main/kotlin/com/bl_lia/kirakiratter/presentation/presenter/KatsuPresenter.kt
@@ -35,7 +35,7 @@ class KatsuPresenter
         TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 
-    fun post(text: String, warning: String? = null, inReplyToId: Int? = null, sensitive: Boolean = false, attachment: List<Uri> = listOf()): Single<Status> {
+    fun post(text: String, warning: String? = null, inReplyToId: Int? = null, sensitive: Boolean = false,visibility: String? = null, attachment: List<Uri> = listOf()): Single<Status> {
 
         if (attachment.isNotEmpty()) {
             return Single.concat(attachment.map { uploadMedia.execute(it) })
@@ -46,6 +46,7 @@ class KatsuPresenter
                                 spoilerText = warning,
                                 inReplyToId = inReplyToId,
                                 sensitive = sensitive,
+                                visibility = visibility,
                                 mediaIds = medias.map { it.id }
                         ))
                     }
@@ -53,7 +54,9 @@ class KatsuPresenter
             return postStatus.execute(StatusForm(
                     status = text,
                     spoilerText = warning,
-                    inReplyToId = inReplyToId
+                    inReplyToId = inReplyToId,
+                    sensitive = sensitive,
+                    visibility = visibility
             ))
         }
     }

--- a/app/src/main/res/drawable/ic_email_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_email_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lock_open_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_open_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6h1.9c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM18,20L6,20L6,10h12v10z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_lock_outline_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_lock_outline_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1s3.1,1.39 3.1,3.1v2L8.9,8L8.9,6zM18,20L6,20L6,10h12v10z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_public_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_public_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM11,19.93c-3.95,-0.49 -7,-3.85 -7,-7.93 0,-0.62 0.08,-1.21 0.21,-1.79L9,15v1c0,1.1 0.9,2 2,2v1.93zM17.9,17.39c-0.26,-0.81 -1,-1.39 -1.9,-1.39h-1v-3c0,-0.55 -0.45,-1 -1,-1L8,12v-2h2c0.55,0 1,-0.45 1,-1L11,7h2c1.1,0 2,-0.9 2,-2v-0.41c2.93,1.19 5,4.06 5,7.41 0,2.08 -0.8,3.97 -2.1,5.39z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_reblog_direct.xml
+++ b/app/src/main/res/drawable/ic_reblog_direct.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#78909C"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_reblog_private.xml
+++ b/app/src/main/res/drawable/ic_reblog_private.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#78909C"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM12,17c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2zM15.1,8L8.9,8L8.9,6c0,-1.71 1.39,-3.1 3.1,-3.1 1.71,0 3.1,1.39 3.1,3.1v2z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_katsu.xml
+++ b/app/src/main/res/layout/fragment_katsu.xml
@@ -93,12 +93,22 @@
 
             <ImageView
                 android:id="@+id/attach_image_1"
-                android:layout_width="60dp"
-                android:layout_height="60dp"
-                android:background="@drawable/ic_camera_alt_black_24px"
-                android:backgroundTint="@android:color/darker_gray"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
                 android:layout_alignParentBottom="true"
-                android:layout_alignParentStart="true" />
+                android:layout_alignParentStart="true"
+                android:background="@drawable/ic_camera_alt_black_24px"
+                android:backgroundTint="@android:color/darker_gray" />
+
+            <Button
+                android:id="@+id/visibility_menu"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_alignParentBottom="true"
+                android:layout_marginStart="8pt"
+                android:layout_toEndOf="@id/attach_image_1"
+                android:background="@drawable/ic_public_black_24dp"
+                android:backgroundTint="@android:color/darker_gray" />
 
             <android.support.v7.widget.SwitchCompat
                 android:id="@+id/switch_content_warning"
@@ -112,9 +122,10 @@
                 android:id="@+id/label_content_warning"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/label_content_warning"
                 android:layout_alignBottom="@+id/button_katsu"
-                android:layout_toStartOf="@+id/button_katsu" />
+                android:layout_alignLeft="@+id/label_not_safe_for_work"
+                android:layout_toStartOf="@+id/button_katsu"
+                android:text="@string/label_content_warning" />
 
             <android.support.v7.widget.SwitchCompat
                 android:id="@+id/switch_not_safe_for_work"
@@ -133,14 +144,14 @@
 
             <Button
                 android:id="@+id/button_katsu"
+                style="@style/Widget.AppCompat.Button.Colored"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="@style/Widget.AppCompat.Button.Colored"
-                android:enabled="false"
-                android:text="@string/button_katsu"
-                android:layout_marginLeft="10dp"
                 android:layout_alignParentBottom="true"
-                android:layout_alignParentEnd="true" />
+                android:layout_alignParentEnd="true"
+                android:layout_marginLeft="10dp"
+                android:enabled="false"
+                android:text="@string/button_katsu" />
 
         </RelativeLayout>
 

--- a/app/src/main/res/menu/menu_visibility.xml
+++ b/app/src/main/res/menu/menu_visibility.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+            <item
+                android:id="@+id/menu_public"
+                android:icon="@drawable/ic_public_black_24dp"
+                android:title="@string/visibility_public"/>
+            <item
+                android:id="@+id/menu_unlisted"
+                android:icon="@drawable/ic_lock_open_black_24dp"
+                android:title="@string/visibility_unlisted"/>
+            <item
+                android:id="@+id/menu_private"
+                android:icon="@drawable/ic_lock_outline_black_24dp"
+                android:title="@string/visibility_private"/>
+            <item
+                android:id="@+id/menu_direct"
+                android:icon="@drawable/ic_email_black_24dp"
+                android:title="@string/visibility_direct"/>
+</menu>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -22,4 +22,10 @@
     <string name="copy_link">リンクをコピー</string>
 
     <string name="image_saved">画像を保存したよ！</string>
+
+    <string name="visibility">public</string>
+    <string name="visibility_public">公開</string>
+    <string name="visibility_unlisted">未収録</string>
+    <string name="visibility_private">非公開</string>
+    <string name="visibility_direct">ダイレクト</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,10 @@
     <string name="copy_link">Copy link</string>
 
     <string name="image_saved">Image saved</string>
+
+    <string name="visibility">public</string>
+    <string name="visibility_public">public</string>
+    <string name="visibility_unlisted">unlist</string>
+    <string name="visibility_private">private</string>
+    <string name="visibility_direct">direct</string>
 </resources>


### PR DESCRIPTION
ご無沙汰しております。

アプリの投稿画面で、投稿範囲を選択できるようにしたのと、タイムラインで表示するStatusが非公開またはダイレクトの場合はブーストのアイコンを変更して、またクリックしても何もしないように変更しました。
投稿画面のレイアウト調整も入っています。

#投稿画面で投稿範囲を選択できるようにし、レイアウト調整していたPR(#154)は、今回のPRに全部含まれていますので、取り下げクローズしました。

